### PR TITLE
Fix card | Animation | Position to display correctly.

### DIFF
--- a/app/_components/MapContainer.tsx
+++ b/app/_components/MapContainer.tsx
@@ -2,14 +2,11 @@
 
 import Image from "next/image";
 import * as React from "react";
-import { useState, } from "react";
+import { useState } from "react";
 import Map, { Marker } from "react-map-gl/maplibre";
 import { sample } from "../_api/sample";
 import PoiPopup from "./PoiPopup";
-import {
-  Popover,
-  PopoverContent,
-} from "@radix-ui/react-popover";
+import { Popover, PopoverContent } from "@radix-ui/react-popover";
 import { Pin } from "../_utils/global";
 import MapContextProvider from "./MapContextProvider";
 import MapControls from "./MapControls";
@@ -33,7 +30,6 @@ function MapInner() {
         onMove={(evt) => setViewPort(evt.viewState)}
         style={{ width: "100vw", height: "100vh" }}
         reuseMaps
-        // disable map rotation since it's not correctly calculated into the bounds atm :')
         dragRotate={false}
         mapStyle={`https://api.protomaps.com/styles/v2/light.json?key=${process.env.NEXT_PUBLIC_PROTOMAPS_API_KEY}`}
       >
@@ -81,26 +77,31 @@ function MapInner() {
                 }}
               />
               {showPopup === pin.id && (
-                <Popover defaultOpen>
-                  <PopoverContent className="absolute bg-transparent left-[50%] top-[50%] grid w-fit max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg">
-                    <PoiPopup setShowPopup={setShowPopup} id={pin.id} payload={payload} />
-                  </PopoverContent>
-                </Popover>
+                <div className="fixed top-0 left-0 w-screen h-screen">
+                  <Popover defaultOpen>
+                    <PopoverContent className="">
+                      <PoiPopup
+                        setShowPopup={setShowPopup}
+                        id={pin.id}
+                        payload={payload}
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </div>
               )}
             </Marker>
           );
         })}
-        <MapControls/>
+        <MapControls />
       </Map>
     </div>
   );
 }
 
-
 const MapContainer = () => (
   <MapContextProvider>
     <MapInner />
   </MapContextProvider>
-)
+);
 
 export default MapContainer;

--- a/app/_components/ui/dialog.tsx
+++ b/app/_components/ui/dialog.tsx
@@ -20,7 +20,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/40  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 w-screen h-screen bg-black/40  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "absolute bg-transparent left-[50%] top-[50%] z-50 grid w-fit max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "h-screen w-screen max-w-lg flex justify-center items-center shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
         className
       )}
     >

--- a/app/_components/ui/dialog.tsx
+++ b/app/_components/ui/dialog.tsx
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "h-screen w-screen max-w-lg flex justify-center items-center shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+        "h-screen w-screen flex justify-center items-center shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
         className
       )}
     >

--- a/app/_components/ui/popover.tsx
+++ b/app/_components/ui/popover.tsx
@@ -1,13 +1,13 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as PopoverPrimitive from "@radix-ui/react-popover"
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Popover = PopoverPrimitive.Root
+const Popover = PopoverPrimitive.Root;
 
-const PopoverTrigger = PopoverPrimitive.Trigger
+const PopoverTrigger = PopoverPrimitive.Trigger;
 
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
@@ -18,14 +18,11 @@ const PopoverContent = React.forwardRef<
       ref={ref}
       align={align}
       sideOffset={sideOffset}
-      className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        className
-      )}
+      className={cn(className)}
       {...props}
     />
   </PopoverPrimitive.Portal>
-))
-PopoverContent.displayName = PopoverPrimitive.Content.displayName
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
-export { Popover, PopoverTrigger, PopoverContent }
+export { Popover, PopoverTrigger, PopoverContent };


### PR DESCRIPTION
# Description

From the previous PR that used the built-in Mapbox-gl CSS stylesheet imported into the global.css, it caused some display issues with the POI card, this PR should solve that, bringing it back to the center of the screen and still and closing by clicking outside the card

## Card Link
https://3.basecamp.com/5802516/buckets/37608217/card_tables/cards/7462293211

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual test on browser

## Checklist before requesting a review
- [x] I have performed a self-review of my code
