### PR TITLE
fix: button will change to text when user click collect instantly

### DIFF
--- a/app/_components/PoiCard.tsx
+++ b/app/_components/PoiCard.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { Button } from "./ui/button";
+import { useEffect, useState } from "react";
 
 export function PoiCard({
   id, // will be used for vaidate the card and mark in future implementation.
@@ -19,6 +20,15 @@ export function PoiCard({
     tags: string[];
   };
 }): JSX.Element {
+  // USE STATE
+  const [collect, setCollect] = useState<boolean>(payload.collect);
+
+  // EFFECT
+  useEffect(() => {}, []);
+
+  // FUNCTION
+
+  // RETURN
   return (
     <section
       className="relative top-0 flex flex-col bg-gray-300 w-[300px] min-h-[600px] max-h-full rounded-2xl overflow-hidden border-solid border-white border-4 z-[999]
@@ -49,12 +59,15 @@ export function PoiCard({
             );
           })}
         </div>
-        {payload.collect ? (
+        {collect ? (
           <p>{payload.description}</p>
         ) : (
           <Button
             className="w-full mt-4 rounded-lg"
-            onClick={() => (payload.collect = true)}
+            onClick={() => {
+              setCollect(true);
+              payload.collect = true;
+            }}
           >
             Collect
           </Button>


### PR DESCRIPTION
# Description

Fix the button to change to description instantly after the user clicks collect instead of going out and going into the card again to update the card state.

## Card Link
https://3.basecamp.com/5802516/buckets/37608217/card_tables/cards/7468917441

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual test
- [x] `run build`

## Checklist before requesting a review
- [x] I have performed a self-review of my code
