### PR TITLE
fix: fix styling and change img to NEXT Image components

### DIFF
--- a/app/_components/MarkerContainer.tsx
+++ b/app/_components/MarkerContainer.tsx
@@ -59,7 +59,6 @@ function MarkerContainer({
     pin.latitude
   );
 
-
   const handleClick = () => {
     setShowPopup(pin.id);
     setSelectedPoiId(pin.id);
@@ -71,7 +70,7 @@ function MarkerContainer({
       longitude={pin.longitude}
       latitude={pin.latitude}
       rotationAlignment="map"
-      style={{ position: "absolute", top: 0, left: 0, opacity: 1, zIndex: 999 }}
+      style={{ position: "absolute", top: 0, left: 0, opacity: 1, zIndex: 50 }}
       offset={[0, 0]}
       anchor="center"
     >

--- a/app/_components/PoidexModal.tsx
+++ b/app/_components/PoidexModal.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Pin } from "../_utils/global";
 import { PoiCard } from "./PoiCard"; // Importing PoiCard
+import Image from "next/image";
 
 interface PoidexModalProps {
   pins: Pin[];
@@ -10,11 +11,21 @@ interface PoidexModalProps {
   goBack: () => void;
 }
 
-const PoidexModal: React.FC<PoidexModalProps> = ({ pins, onClose, onPoiClick, selectedPoi, goBack }) => {
+const PoidexModal: React.FC<PoidexModalProps> = ({
+  pins,
+  onClose,
+  onPoiClick,
+  selectedPoi,
+  goBack,
+}) => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="absolute inset-0 bg-black opacity-50"></div>
-      <dialog open className="relative bg-white rounded-lg overflow-hidden p-4" style={{ width: selectedPoi ? '60%' : '80%', maxWidth: '1000px' }}>
+      <dialog
+        open
+        className="relative bg-white rounded-lg overflow-hidden p-4"
+        style={{ width: selectedPoi ? "60%" : "80%", maxWidth: "1000px" }}
+      >
         <button
           onClick={onClose}
           className="absolute top-2 right-2 text-black bg-red-500 rounded-full p-2 z-50"
@@ -31,9 +42,19 @@ const PoidexModal: React.FC<PoidexModalProps> = ({ pins, onClose, onPoiClick, se
                 <div
                   key={pin.id}
                   onClick={pin.collect ? () => onPoiClick(pin) : undefined}
-                  className={`flex flex-col items-center  ${pin.collect ? 'cursor-pointer' : 'opacity-50 cursor-not-allowed'}`}
+                  className={`flex flex-col items-center  ${
+                    pin.collect
+                      ? "cursor-pointer"
+                      : "opacity-50 cursor-not-allowed"
+                  }`}
                 >
-                  <img src={pin.collect ? pin.img_url : "/UnknownIcon.png"} alt={pin.title} className="w-full h-auto max-h-32 object-contain" />
+                  <Image
+                    src={pin.collect ? pin.img_url : "/UnknownIcon.png"}
+                    alt={pin.title}
+                    width={100}
+                    height={100}
+                    className="w-full h-auto max-h-32 object-contain"
+                  />
                   <h2 className="text-center mt-2">
                     {pin.collect ? pin.title : "???"}
                   </h2>
@@ -50,7 +71,10 @@ const PoidexModal: React.FC<PoidexModalProps> = ({ pins, onClose, onPoiClick, se
               Back
             </button>
             <div className="z-[9999] fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
-              <PoiCard id={selectedPoi.id} payload={{ ...selectedPoi, collect: selectedPoi.collect }} />
+              <PoiCard
+                id={selectedPoi.id}
+                payload={{ ...selectedPoi, collect: selectedPoi.collect }}
+              />
             </div>
           </div>
         )}


### PR DESCRIPTION
# Description

Fix the marker that appears on top of the Poidex dialog window. Now, when users open the poidex, it should stay behind the window.

## Card Link
https://3.basecamp.com/5802516/buckets/37608217/card_tables/cards/7473220985

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual Test

## Checklist before requesting a review
- [x] I have performed a self-review of my code