### PR TITLE
Feat/submit guess button

### DIFF
--- a/app/_components/MapContainer.tsx
+++ b/app/_components/MapContainer.tsx
@@ -13,6 +13,7 @@ import PoidexButton from "./PoidexButton";
 import PoidexModal from "./PoidexModal";
 import DistanceHintButton from "./DistanceHintButton";
 import HintButton from "./HintButton";
+import SubmitGuessButton from "./SubmitGuessButton";
 
 function MapInner() {
   const [showPopup, setShowPopup] = useState<number | undefined>(undefined);
@@ -79,6 +80,7 @@ function MapInner() {
           );
         })}
         <DistanceHintButton pins={sample.pin}/>
+        <SubmitGuessButton pins={sample.pin}/>
         <MapControls />
       </Map>
       {showPoidex ? (

--- a/app/_components/SubmitGuessButton.tsx
+++ b/app/_components/SubmitGuessButton.tsx
@@ -79,6 +79,7 @@ function SubmitGuessButton({
     navigator.geolocation.getCurrentPosition(position => {
       const { latitude, longitude } = position.coords;
       console.log(`user location is lat: ${latitude}, long: ${longitude}`)
+      console.log(`user is ${distanceToPin} away from the poi`)
     },
     error => {
       console.error('Error getting location:', error);

--- a/app/_components/SubmitGuessButton.tsx
+++ b/app/_components/SubmitGuessButton.tsx
@@ -1,0 +1,98 @@
+import { useState, useEffect } from "react";
+import { Button } from "./ui/button";
+import { Pin } from "../_utils/global";
+import {
+  Coordinates,
+  GetDistanceFromCoordinatesToMeters,
+} from "../_utils/coordinateMath";
+
+
+interface SubmitGuessButtonProps {
+  pins: Pin[];
+}
+
+/**
+ * TODO: Manage Button states based on closest pin's search radius.
+ * This can done by constantly checking the user coordinates.
+ * Manage how frequent this call is made.
+ **/
+
+function SubmitGuessButton({
+  pins,
+}: SubmitGuessButtonProps): React.JSX.Element {
+  const [trackingPin, setTrackingPin] = useState<Pin | null>(null);
+  const [distanceToPin, setDistanceToPin] = useState<number>(0);
+  const [isActiveState, setIsActiveState] = useState<boolean>(false);
+
+  useEffect(() => {
+    const id = navigator.geolocation.watchPosition((position) => {
+      handleTrackingPinAndDistanceToPin(position.coords);
+    });
+    return () => navigator.geolocation.clearWatch(id);
+  });
+
+  useEffect(() => {
+    if (!trackingPin) return;
+    setIsActiveState(isWithinSearchZone());
+  }, [trackingPin, distanceToPin]);
+
+
+  const handleTrackingPinAndDistanceToPin = (
+    userCoords: GeolocationCoordinates
+  ) => {
+    const userCoordinates: Coordinates = {
+      longitude: userCoords.longitude,
+      latitude: userCoords.latitude,
+    };
+    let shortestDistance: number = Number.MAX_SAFE_INTEGER;
+    let pinToTrack: Pin | null = null;
+
+    //Finds the closest pin
+    for (const pin of pins) {
+      //Change based on new schema
+      if(pin.collect){
+        continue;
+      }
+      const pinCoordinates: Coordinates = {
+        longitude: pin.longitude,
+        latitude: pin.latitude,
+      };
+      const distance: number = GetDistanceFromCoordinatesToMeters(
+        userCoordinates,
+        pinCoordinates
+      );
+      if (distance < shortestDistance) {
+        shortestDistance = distance;
+        pinToTrack = pin;
+      }
+    }
+    setTrackingPin(pinToTrack);
+    setDistanceToPin(shortestDistance);
+  };
+
+  const isWithinSearchZone = (): boolean => {
+    if (trackingPin) return distanceToPin < trackingPin.radius;
+    else return false;
+  };
+
+  const handleSubmitGuessOnClick = () => {
+    navigator.geolocation.getCurrentPosition(position => {
+      const { latitude, longitude } = position.coords;
+      console.log(`user location is lat: ${latitude}, long: ${longitude}`)
+    })
+  };
+
+  const handleButtonTextRender = ():string => {
+   return "Submit your answer?";
+  }
+
+  return (
+    <div className="fixed left-50 bottom-20 w-auto h-auto" style = {{visibility: (isActiveState)? "visible" : "hidden"}}>
+      <Button disabled={!isActiveState} onClick={handleSubmitGuessOnClick}>
+        {handleButtonTextRender()}
+      </Button>
+    </div>
+  );
+}
+
+export default SubmitGuessButton;

--- a/app/_components/SubmitGuessButton.tsx
+++ b/app/_components/SubmitGuessButton.tsx
@@ -79,7 +79,16 @@ function SubmitGuessButton({
     navigator.geolocation.getCurrentPosition(position => {
       const { latitude, longitude } = position.coords;
       console.log(`user location is lat: ${latitude}, long: ${longitude}`)
-    })
+    },
+    error => {
+      console.error('Error getting location:', error);
+    },
+    {
+      enableHighAccuracy: true,
+      timeout: 5000,
+      maximumAge: 0
+    }
+  )
   };
 
   const handleButtonTextRender = ():string => {
@@ -87,12 +96,15 @@ function SubmitGuessButton({
   }
 
   return (
-    <div className="fixed left-50 bottom-20 w-auto h-auto" style = {{visibility: (isActiveState)? "visible" : "hidden"}}>
-      <Button disabled={!isActiveState} onClick={handleSubmitGuessOnClick}>
+    <div
+    className="fixed bottom-20 left-0 w-full h-20 flex justify-center items-center"
+    style={{ visibility: isActiveState ? "visible" : "hidden" }}>
+      <Button className="w-full h-full" disabled={!isActiveState} onClick={handleSubmitGuessOnClick}>
         {handleButtonTextRender()}
       </Button>
     </div>
   );
+
 }
 
 export default SubmitGuessButton;


### PR DESCRIPTION
# Description

There is now a button that only appears f the user in in a search zone, currently, clicking it will console log the user's coodinates and the distance from the nearest poi. realistically the poi of the search zone they're in

## Card Link

https://3.basecamp.com/5802516/buckets/37608217/card_tables/cards/7478262404

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested it locally by checking the console log and checking different distances from various pois

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
