### PR TITLE
feat: implement frontend for posting hints if within a certain distance from POI

### DIFF
--- a/app/_components/HintModal.tsx
+++ b/app/_components/HintModal.tsx
@@ -1,0 +1,64 @@
+import { useState, useRef, useEffect } from 'react';
+import { Button } from './ui/button';
+
+interface HintModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  distanceToPin: number;
+  thresholdDistance: number;
+  onSubmitHint: (hint: string) => void;
+}
+
+const HintModal = ({ isOpen, onClose, distanceToPin, thresholdDistance, onSubmitHint }: HintModalProps) => {
+  const [hint, setHint] = useState('');
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      dialogRef.current?.showModal();
+    } else {
+      dialogRef.current?.close();
+    }
+  }, [isOpen]);
+
+  const isCloseEnough = distanceToPin <= thresholdDistance; //Checking if distance is less than the minimum hint requirement
+
+  const handleSubmit = () => {
+    onSubmitHint(hint);
+    setHint('');
+    onClose();
+  };
+
+  return (
+    <dialog ref={dialogRef} className="rounded-lg shadow-lg p-6 bg-white">
+      {isCloseEnough ? (
+        <>
+          <h2>{`Nice Guessing! How about leaving a hint for someone else?`}</h2>
+          <p>{`(Be sure to be helpful! But don't just give it away!)`}</p>
+          <input
+            type="text"
+            value={hint}
+            onChange={(e) => setHint(e.target.value)}
+            className="border p-2 mt-2 w-full"
+          />
+          <div className="mt-4 flex justify-end">
+            <Button onClick={handleSubmit} className="mr-2">
+              Submit Hint
+            </Button>
+            <Button onClick={onClose}>Close</Button>
+          </div>
+        </>
+      ) : (
+        <>
+          <h2>{`Nice try! We'll still give you some points but try and get closer next time!`}</h2>
+          <p>{`(You'll even be able to leave a hint if you're close enough!)`}</p>
+          <div className="mt-4 flex justify-end">
+            <Button onClick={onClose}>Close</Button>
+          </div>
+        </>
+      )}
+    </dialog>
+  );
+};
+
+export default HintModal;


### PR DESCRIPTION
# Description
The user, if logged in, can post a hint if within a certain distance from with poi. Currently it is tentatively set at 50 meters.
Currently it only console logs the hint and needs to still be connected to the backend DB

## Card Link
https://3.basecamp.com/5802516/buckets/37608217/card_tables/cards/7478319523

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested within a search zone, within the 50 meter limit and was able to successfully "post" a hint.
- [x] Manually tested withing a search zone, outside the 50 meter limit and was given a message saying I'm not close enough to post a hint

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
