### PR TITLE
feat: the button from the poi card can now set a pin to track if the …

### DIFF
--- a/app/_components/MapContainer.tsx
+++ b/app/_components/MapContainer.tsx
@@ -21,6 +21,7 @@ import GuessPolyline from "./ui/guessPolyline";
 import PopoverCard from "./PopoverCard";
 import GuessDistanceModal from "./GuessDistanceModal";
 import PoiPhotoToggle from "./PoiPhotoToggle";
+import TrackingPinContextProvider, {TrackingPinContext} from "./useContext/TrackingPinContext";
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
@@ -40,6 +41,8 @@ function MapInner() {
   const [userCoordinates, setUserCoordinates] = useState<Coordinates|null>(null);
   const [closestNotCompletedPin, setClosestNotCompletedPin] = useState<Pin|null> (null);
   const [distanceToTrackingPin, setDistanceToTrackingPin] = useState<number|null> (null);
+  
+  
   // const [isTrackingTheClosestPin, setIsTrackingTheClosestPin] = useState<boolean> (true);
 
   // Default camera map when user opens the app
@@ -52,12 +55,17 @@ function MapInner() {
   });
 
   const user = useContext(AuthContext);
-
+  const trackingPinContext = useContext(TrackingPinContext);
+  
   // USE EFFECT
   useEffect(() => {
     user ? void handleFetchPoiByUid() : void handleFetchPoiByAnonymous();
     void handleFetchFilters();
   }, [user]);
+
+  useEffect(() => {
+    console.log(trackingPinContext?.trackingPin);
+  },[trackingPinContext?.trackingPin])
 
   useEffect(() => {
     if(!closestNotCompletedPin || !userCoordinates) return;
@@ -259,9 +267,11 @@ function MapInner() {
 }
 
 const MapContainer = () => (
-  <MapContextProvider>
-    <MapInner />
-  </MapContextProvider>
+  <TrackingPinContextProvider>
+    <MapContextProvider>
+      <MapInner />
+    </MapContextProvider>
+  </TrackingPinContextProvider>
 );
 
 export default MapContainer;

--- a/app/_components/useContext/TrackingPinContext.tsx
+++ b/app/_components/useContext/TrackingPinContext.tsx
@@ -1,0 +1,24 @@
+"use client"
+import { createContext, useState } from "react";
+import { Pin } from "./../../_utils/global";
+
+interface TrackingPinContextValues {
+  trackingPin: Pin | null
+  setTrackingPin: (e: Pin | null) => void
+}
+
+export const TrackingPinContext = createContext<TrackingPinContextValues | undefined>(undefined);
+
+interface TrackingPinProviderProps {
+  children: React.ReactNode;
+}
+
+const TrackingPinContextProvider = ({ children }: TrackingPinProviderProps) => {
+  const [trackingPin, setTrackingPin] = useState<Pin | null>(null);
+
+  return <TrackingPinContext.Provider value={{trackingPin, setTrackingPin}}>
+    {children}
+  </TrackingPinContext.Provider>
+}
+
+export default TrackingPinContextProvider;


### PR DESCRIPTION
# Description

The user can now select a pin an display the poi card of that pin. If the player is not within that Poi's search radius the player now has the option to track the pin. The result can be reflected in the console log.

## Card Link
https://3.basecamp.com/5802516/buckets/37608217/card_tables/cards/7488201630

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested manually. The result can be seen in the console.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested this manually on the front end
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
