### PR TITLE
Fix/stop pan after guess

### DIFF
--- a/app/_components/MainQuest.tsx
+++ b/app/_components/MainQuest.tsx
@@ -28,10 +28,10 @@ const MainQuest = ({ closestNotCompletedPin: closestPin }: MainQuestProps) => {
     console.log(trackingPinContext?.trackingPin);
     if (!trackingPinContext || !trackingPinContext.trackingPin) {
       setIsTracking(false);
-      setPinToPanTo(closestPin);
+      setPinToPanTo((closestPin?.is_completed) ? null : closestPin);
       return;
     }
-    if (!closestPin) {
+    if (!closestPin || closestPin.is_completed) {
       setPinToPanTo(null);
       return;
     }

--- a/app/_components/MapControls.tsx
+++ b/app/_components/MapControls.tsx
@@ -14,7 +14,7 @@ const MapControls = (): React.JSX.Element => {
     if (!trackingPinContext.trackingPin) return;
     console.table(trackingPinContext.trackingPin);
       handlePanMapToTrackingPin(trackingPinContext.trackingPin);
-  },[trackingPinContext, trackingPinContext?.trackingPin])
+  },[trackingPinContext?.trackingPin])
 
   const handlePanMapToTrackingPin = (pin: Pin) => {
     try {

--- a/app/_components/PoiCard.tsx
+++ b/app/_components/PoiCard.tsx
@@ -135,6 +135,10 @@ export function PoiCard({
       });
     payload.is_completed = true;
     if (!importantPinContext) return;
+    if (importantPinContext.trackingPin?.poi_id == payload.poi_id)
+    {
+      importantPinContext.setTrackingPin(null);
+    }
     importantPinContext.setGuessedPin(payload);
   };
 


### PR DESCRIPTION
# Description

The camera will no longer pan the camera to the tracking pin after submitting a guess.
The Main Quest will no longer track a pin that is completed. Instead it is set to null until the user moves location, then it will be set to the closest pin.

## Card Link
https://3.basecamp.com/5802516/buckets/37608217/card_tables/cards/7498361294

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I have tested this manually on the browser.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
