### PR TITLE
Refactor/guessPolyLine and GuessDistanceModal have relevant information passed from MapContainer

### DIFF
--- a/app/_components/GuessDistanceModal.tsx
+++ b/app/_components/GuessDistanceModal.tsx
@@ -1,36 +1,36 @@
-import { useContext, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Drawer, DrawerContent, DrawerTrigger } from "./ui/drawer";
 import {
   Coordinates,
   GetDistanceFromCoordinatesToMeters,
 } from "../_utils/coordinateMath";
 import { Button } from "./ui/button";
-import { ImportantPinContext } from "./useContext/ImportantPinContext";
 import { Pin } from "../_utils/global";
 import { Input } from "./ui/input";
 import { Label } from "@radix-ui/react-label";
 
 const GuessDistanceModal = ({
-  guessPoiPosition,
-  setGuessPoiPosition,
+  guessedPin,
+  setGuessedPin,
+  // guessPoiPosition,
   userCoordinates,
   score,
 }: {
-  guessPoiPosition: Coordinates;
-  setGuessPoiPosition: (arg0: Coordinates | null) => void;
+  guessedPin: Pin
+  // guessPoiPosition: Coordinates;
+  setGuessedPin: (arg0: Pin | null) => void;
   userCoordinates: Coordinates;
   score: number | null;
 }) => {
-  const importantPinContext = useContext(ImportantPinContext);
   const [distanceToPin, setDistancePin] = useState<number>(0);
   const [hint, setHint] = useState<string>("");
   const drawerRef = useRef<HTMLButtonElement>(null); // Ref for the Done button
   const thresholdDistance = 20;
 
   useEffect(() => {
-    if (!importantPinContext || !importantPinContext.guessedPin) return;
-    handleDistanceToPin(importantPinContext.guessedPin, userCoordinates);
-  }, [importantPinContext?.guessedPin]);
+    if (!guessedPin) return;
+    handleDistanceToPin(guessedPin, userCoordinates);
+  }, [guessedPin]);
 
   const handleDistanceToPin = (
     guessedPin: Pin,
@@ -50,7 +50,7 @@ const GuessDistanceModal = ({
 
   const handleSubmitHint = async () => {
     const hintData = {
-      poi_id: importantPinContext?.guessedPin?.poi_id,
+      poi_id: guessedPin,
       content: hint,
     };
     console.log(hintData);
@@ -94,20 +94,10 @@ const GuessDistanceModal = ({
           <p className="mb-4">
             You guessed{" "}
             <span className="text-primary font-semibold">
-              {GetDistanceFromCoordinatesToMeters(
-                userCoordinates,
-                guessPoiPosition
-              ) > 1000
-                ? (
-                    GetDistanceFromCoordinatesToMeters(
-                      userCoordinates,
-                      guessPoiPosition
-                    ) / 1000
-                  ).toFixed(2) + "km"
-                : GetDistanceFromCoordinatesToMeters(
-                    userCoordinates,
-                    guessPoiPosition
-                  ).toFixed(2) + "m"}{" "}
+              { distanceToPin > 1000
+                ? (distanceToPin / 1000)
+                  .toFixed(2) + "km"
+                : distanceToPin.toFixed(2) + "m"}{" "}
             </span>
             away from the picture and your score is{" "}
             <span className="text-primary font-semibold">{score}</span>! Good
@@ -143,7 +133,8 @@ const GuessDistanceModal = ({
                   ref={drawerRef}
                   onClick={() => {
                     handleSubmitClick;
-                    setGuessPoiPosition(null);
+                    // setGuessPoiPosition(null);
+                    setGuessedPin(null);
                   }}
                   className="w-full"
                 >
@@ -153,7 +144,8 @@ const GuessDistanceModal = ({
                   variant={"link"}
                   ref={drawerRef}
                   onClick={() => {
-                    setGuessPoiPosition(null);
+                    // setGuessPoiPosition(null);
+                    setGuessedPin(null);
                   }}
                   className="w-full"
                 >
@@ -169,7 +161,8 @@ const GuessDistanceModal = ({
                 variant={"link"}
                 ref={drawerRef}
                 onClick={() => {
-                  setGuessPoiPosition(null);
+                  // setGuessPoiPosition(null);
+                  setGuessedPin(null);
                 }}
                 className="w-full"
               >

--- a/app/_components/MapContainer.tsx
+++ b/app/_components/MapContainer.tsx
@@ -281,15 +281,18 @@ function MapInner() {
         )}
 
         {/* GUESS MODEL */}
-        {userCoordinates && guessPoiPosition !== null && (
+        {userCoordinates && importantPinContext && importantPinContext.guessedPin && (
           <>
             <GuessPolyline
               userLocation={userCoordinates}
-              guessPoiLocation={guessPoiPosition}
+              guessPoiLocation={{
+                longitude: importantPinContext.guessedPin.exact_longitude,
+                latitude: importantPinContext.guessedPin.exact_latitude
+              } as Coordinates}
             />
             <GuessDistanceModal
-              guessPoiPosition={guessPoiPosition}
-              setGuessPoiPosition={setGuessPoiPosition}
+              guessedPin = {importantPinContext.guessedPin}
+              setGuessedPin={importantPinContext.setGuessedPin}
               userCoordinates={userCoordinates}
               score={score}
             />

--- a/app/_components/MapContainer.tsx
+++ b/app/_components/MapContainer.tsx
@@ -42,9 +42,9 @@ function MapInner() {
   // USE STATE
   const [poiData, setPoiData] = useState<Pin[]>([]);
   const [showPopup, setShowPopup] = useState<boolean>(false);
-  const [guessPoiPosition, setGuessPoiPosition] = useState<Coordinates | null>(
-    null
-  );
+  // const [guessPoiPosition, setGuessPoiPosition] = useState<Coordinates | null>(
+  //   null
+  // );
   // const [filteredPins, setFilteredPins] = useState(sample.pin);
   const [selectedPoiId, setSelectedPoiId] = useState<number | undefined>(
     undefined
@@ -274,7 +274,6 @@ function MapInner() {
             poiData={poiData}
             selectedPoiId={selectedPoiId}
             setShowPopup={setShowPopup}
-            setGuessPoiPosition={setGuessPoiPosition}
             userCoordinates={userCoordinates}
             setScore={setScore}
           />

--- a/app/_components/MapContainer.tsx
+++ b/app/_components/MapContainer.tsx
@@ -61,6 +61,7 @@ function MapInner() {
   >(null);
 
   const [score, setScore] = useState<number | null>(null);
+  const [userCoordinatesAtMomentOfGuess, setUserGuessCoord] = useState<Coordinates | null>(null);
 
   // const [isTrackingTheClosestPin, setIsTrackingTheClosestPin] = useState<boolean> (true);
 
@@ -90,6 +91,15 @@ function MapInner() {
     if (!closestNotCompletedPin || !userCoordinates) return;
     handleDistanceToClosestPin(userCoordinates, closestNotCompletedPin);
   }, [closestNotCompletedPin, userCoordinates]);
+
+  useEffect(() => {
+    if (!importantPinContext?.guessedPin) {
+      setUserGuessCoord(null)
+    }
+    if (!userCoordinates) return;
+    const currentUserCoordinates:Coordinates = userCoordinates;
+    setUserGuessCoord(currentUserCoordinates)
+  },[importantPinContext?.guessedPin]);
 
   // HANDLER FUNCTION
   const handleFetchPoiByUid = async () => {
@@ -280,10 +290,10 @@ function MapInner() {
         )}
 
         {/* GUESS MODEL */}
-        {userCoordinates && importantPinContext && importantPinContext.guessedPin && (
+        {userCoordinatesAtMomentOfGuess && importantPinContext && importantPinContext.guessedPin && (
           <>
             <GuessPolyline
-              userLocation={userCoordinates}
+              userLocation={userCoordinatesAtMomentOfGuess}
               guessPoiLocation={{
                 longitude: importantPinContext.guessedPin.exact_longitude,
                 latitude: importantPinContext.guessedPin.exact_latitude
@@ -292,7 +302,7 @@ function MapInner() {
             <GuessDistanceModal
               guessedPin = {importantPinContext.guessedPin}
               setGuessedPin={importantPinContext.setGuessedPin}
-              userCoordinates={userCoordinates}
+              userCoordinates={userCoordinatesAtMomentOfGuess}
               score={score}
             />
           </>

--- a/app/_components/PoiCard.tsx
+++ b/app/_components/PoiCard.tsx
@@ -16,14 +16,12 @@ const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 export function PoiCard({
   id,
   payload,
-  setGuessPoiPosition,
   setShowPopup,
   userCoordinates,
   setScore,
 }: {
   id: number;
   payload: Pin;
-  setGuessPoiPosition?: (arg0: Coordinates | null) => void;
   setShowPopup?: (arg0: boolean) => void;
   userCoordinates: Coordinates | null;
   setScore: (arg0: number|null) => void;
@@ -128,11 +126,6 @@ export function PoiCard({
   const updatePoi = () => {
     setCollect(true);
     setShowPopup && setShowPopup(false);
-    setGuessPoiPosition &&
-      setGuessPoiPosition({
-        latitude: payload.exact_latitude,
-        longitude: payload.exact_longitude,
-      });
     payload.is_completed = true;
     if (!importantPinContext) return;
     importantPinContext.setGuessedPin(payload);

--- a/app/_components/PoiPopup.tsx
+++ b/app/_components/PoiPopup.tsx
@@ -11,14 +11,12 @@ export default function PoiPopup({
   id,
   payload,
   setShowPopup,
-  setGuessPoiPosition,
   userCoordinates,
   setScore
 }: {
   id: number;
   payload: Pin;
   setShowPopup: (arg0: boolean) => void;
-  setGuessPoiPosition: (arg0: Coordinates | null) => void;
   userCoordinates: Coordinates | null;
   setScore: (arg0: number|null) => void;
 }): JSX.Element {
@@ -31,7 +29,6 @@ export default function PoiPopup({
           <PoiCard
             id={id}
             payload={payload}
-            setGuessPoiPosition={setGuessPoiPosition}
             setShowPopup={setShowPopup}
             userCoordinates={userCoordinates}
             setScore={setScore}

--- a/app/_components/PopoverCard.tsx
+++ b/app/_components/PopoverCard.tsx
@@ -7,14 +7,12 @@ const PopoverCard = ({
   poiData,
   selectedPoiId,
   setShowPopup,
-  setGuessPoiPosition,
   userCoordinates,
   setScore
 }: {
   poiData: Pin[];
   selectedPoiId: number;
   setShowPopup: (arg0: boolean) => void;
-  setGuessPoiPosition?: (arg0: Coordinates | null) => void;
   userCoordinates?: Coordinates | null;
   setScore: (arg0: number|null) => void;
 }) => {
@@ -22,11 +20,10 @@ const PopoverCard = ({
     <div className="fixed top-0 left-0 w-screen h-screen">
       <Popover defaultOpen>
         <PopoverContent>
-          {setShowPopup && setGuessPoiPosition && userCoordinates && (
+          {setShowPopup && userCoordinates && (
             <PoiPopup
               id={selectedPoiId}
               setShowPopup={setShowPopup}
-              setGuessPoiPosition={setGuessPoiPosition}
               payload={poiData.filter((pin) => pin.poi_id === selectedPoiId)[0]}
               userCoordinates={userCoordinates}
               setScore={setScore}


### PR DESCRIPTION
# Description

The use can still guess as normal without prop drilling to pass the relevant information to display guess.
Fixed a bug where the guess location would follow the user AFTER guessing.

## Card Link
https://3.basecamp.com/5802516/buckets/37608217/card_tables/cards/7494131717

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

I have tested this manually on the browser. Needs more manual testing

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
