### PR TITLE
hint bug PR

### DIFF
--- a/app/_components/PoiCard.tsx
+++ b/app/_components/PoiCard.tsx
@@ -41,7 +41,9 @@ export function PoiCard({
     longitude: search_longitude,
   };
   //hint useStates
-  const [hints, setHints] = useState<string[] | undefined[]>([]);
+  const [hints, setHints] = useState<string[] | undefined[]>([
+    "You sure? Click again to show hints!",
+  ]);
 
   // HANDLERS FUNCTIONS
   const handleCheckUserInSearchZone = (): boolean => {
@@ -153,7 +155,7 @@ export function PoiCard({
       if (!userCoordinates) throw "No user coordinates";
 
       await getHints(user, payload);
-      toastHintCycle();
+      //toastHintCycle();
     } catch (error) {
       console.error("Error", error);
     }
@@ -161,16 +163,20 @@ export function PoiCard({
 
   //cycle thru hints in toast
   const toastHintCycle = (i: number = 0) => {
-    toast("Hint:", {
-      description: hints[i],
-      action: {
-        label: "next hint",
-        onClick: () => {
-          const nextIndex = (i + 1) % hints.length; // Calculate the index of the next hint
-          toastHintCycle(nextIndex);
+    if (hints[0] === "You sure? Click again to show hints!") {
+      toast(hints[0]);
+    } else {
+      toast("Hint:", {
+        description: hints[i],
+        action: {
+          label: "next hint",
+          onClick: () => {
+            const nextIndex = (i + 1) % hints.length; // Calculate the index of the next hint
+            toastHintCycle(nextIndex);
+          },
         },
-      },
-    });
+      });
+    }
   };
 
   //get hints
@@ -273,7 +279,7 @@ export function PoiCard({
             <Button
               id={`${id}`}
               className="w-full mt-4 rounded-lg"
-              onClick={(): void => {
+              onClick={async (): Promise<void> => {
                 if (!user) {
                   alert("please login");
                   return;
@@ -284,8 +290,9 @@ export function PoiCard({
                     setShowPopup && setShowPopup(false);
                   }
                 } else {
-                  //may be empty bc still fetching from handleGetHintOnClick
-                  void handleGetHintOnClick(user, payload, userCoordinates);
+                  // empty bc using OG useState; separating the functions like this doesn't solve it
+                  await handleGetHintOnClick(user, payload, userCoordinates);
+                  toastHintCycle();
                 }
               }}
             >


### PR DESCRIPTION
# Description
First "hint" was always empty because it was getting the original "hints" state, before being set. Extracting the fetch from the toast logic didn't help, so as a solution the first click of "Hint" will display an "are you sure? click again for hints!" notification. Clicking the second time will fetch hints correctly.
## Card Link
https://3.basecamp.com/5802516/buckets/37608217/card_tables/cards/7503288098
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Locally

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
