### PR TITLE
fix: z-index bug and restyle to sub-menu

### DIFF
--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -1,19 +1,18 @@
 import MapContainer from "../_components/MapContainer";
 import { AuthProvider } from "../_components/useContext/AuthContext";
 import Link from "next/link";
-import { BsQuestionDiamondFill } from "react-icons/bs";
-import { ButtonIconCircle } from "../_components/ui/MenuIconCircle";
-
+import { BsQuestionCircleFill } from "react-icons/bs";
 
 export default function Home(): JSX.Element {
   return (
     <div className="absolute inset-0 bg-mapBg">
       <AuthProvider>
         <MapContainer />
-        <Link className="fixed bottom-20 left-5" href="/how-to-play">
-          <ButtonIconCircle text="Tutorial">
-          <BsQuestionDiamondFill size={24}/>
-          </ButtonIconCircle>
+        <Link className="fixed top-56 right-2.5 z-[50]" href="/how-to-play">
+          <BsQuestionCircleFill
+            size={30}
+            className="text-white bg-primary rounded-full shadow-2xl"
+          />
         </Link>
       </AuthProvider>
     </div>


### PR DESCRIPTION
# Description

fix the tutorial icon's z-index to the correct level. Restyle the icon to a secondary icon. Group it with the navigation menu since the exp bar will be displayed at the bottom of the screen.

## Card Link
https://3.basecamp.com/5802516/buckets/37608217/card_tables/cards/7508073953

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual test

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules