### PR TITLE
style: relocate state to check if user open poiDex, default will acti…

### DIFF
--- a/app/_components/GameControls.tsx
+++ b/app/_components/GameControls.tsx
@@ -8,6 +8,7 @@ import { Coordinates } from "../_utils/coordinateMath";
 
 import { Pin } from "../_utils/global";
 import Link from "next/link";
+import { useState } from "react";
 
 interface GameControlsProps {
   pins: Pin[];
@@ -22,15 +23,17 @@ const GameControls = ({
 // userCoordinates,
 // distanceToTrackingPin,
 GameControlsProps): React.JSX.Element => {
+  const [showPoidex, setShowPoidex] = useState<boolean>(false);
+
   return (
     <div className="flex justify-between min-w-[360px] max-w-full">
       <Link href={"/map"}>
-        <ButtonIconCircle text="Map">
+        <ButtonIconCircle text="Map" variant={!showPoidex ? "active" : "default"}>
           <FaMapLocationDot size={24} />
         </ButtonIconCircle>
       </Link>
 
-      <Poidex pins={pins} />
+      <Poidex pins={pins} setShowPoidex={setShowPoidex} showPoidex={showPoidex} />
 
       <Link href="/leaderboard">
         <ButtonIconCircle text="leaderboard">

--- a/app/_components/Poidex.tsx
+++ b/app/_components/Poidex.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import PoidexModal from "./PoidexModal";
 import { Pin } from "../_utils/global";
 import { BsCollectionFill } from "react-icons/bs";
@@ -6,11 +5,15 @@ import { ButtonIconCircle } from "./ui/MenuIconCircle";
 
 interface PoidexProps {
   pins: Pin[];
+  setShowPoidex: (arg0: boolean) => void;
+  showPoidex: boolean;
 }
 
-const Poidex = ({ pins }: PoidexProps): React.JSX.Element => {
-  const [showPoidex, setShowPoidex] = useState<boolean>(false);
-
+const Poidex = ({
+  pins,
+  setShowPoidex,
+  showPoidex,
+}: PoidexProps): React.JSX.Element => {
   return (
     <>
       <ButtonIconCircle


### PR DESCRIPTION
# Description

Minor style change in footer menu, now map menu will be set to active state when user on the map page without open the poiDex. If they open poiDex, map will be set to default and poiDex will be set to active

## Card Link
https://3.basecamp.com/5802516/buckets/37608217/card_tables/cards/7511371636

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manaul test

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
