### PR TITLE
Fix/guess distance modal display distance

### DIFF
--- a/app/_components/GuessDistanceModal.tsx
+++ b/app/_components/GuessDistanceModal.tsx
@@ -23,7 +23,7 @@ const GuessDistanceModal = ({
   const [hint, setHint] = useState<string>("");
   const drawerRef = useRef<HTMLButtonElement>(null); // Ref for the Done button
   const thresholdDistance = 20;
-  const distanceToGuessedPin = handleDistanceToPin(guessedPin, userCoordinates);
+  const distanceToGuessedPinExactLocation = handleDistanceToPin(guessedPin, userCoordinates);
   
   function handleDistanceToPin(
     guessedPin: Pin,
@@ -88,9 +88,9 @@ const GuessDistanceModal = ({
           <p className="mb-4">
             You guessed{" "}
             <span className="text-primary font-semibold">
-              {distanceToGuessedPin > 1000
-                ? (distanceToGuessedPin / 1000).toFixed(2) + "km"
-                : distanceToGuessedPin.toFixed(2) + "m"}{" "}
+              {distanceToGuessedPinExactLocation > 1000
+                ? (distanceToGuessedPinExactLocation / 1000).toFixed(2) + "km"
+                : distanceToGuessedPinExactLocation.toFixed(2) + "m"}{" "}
             </span>
             away from the picture and your score is{" "}
             <span className="text-primary font-semibold">{score}</span>! Good
@@ -101,7 +101,7 @@ const GuessDistanceModal = ({
           </DrawerTrigger>
         </div>
         <DrawerContent>
-          {distanceToGuessedPin < thresholdDistance ? (
+          {distanceToGuessedPinExactLocation < thresholdDistance ? (
             <div className="p-4">
               <h2>
                 {" "}

--- a/app/_components/GuessDistanceModal.tsx
+++ b/app/_components/GuessDistanceModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Drawer, DrawerContent, DrawerTrigger } from "./ui/drawer";
 import {
   Coordinates,
@@ -23,14 +23,8 @@ const GuessDistanceModal = ({
   const [hint, setHint] = useState<string>("");
   const drawerRef = useRef<HTMLButtonElement>(null); // Ref for the Done button
   const thresholdDistance = 20;
-  const distanceToPinRef = useRef<number>(handleDistanceToPin(guessedPin, userCoordinates));
-
-  useEffect(() => {
-    console.log("Guess Modal Mounted");
-
-    return () => console.log("Unmounting");
-  },[]);
-
+  const distanceToGuessedPin = handleDistanceToPin(guessedPin, userCoordinates);
+  
   function handleDistanceToPin(
     guessedPin: Pin,
     userCoordinates: Coordinates
@@ -94,9 +88,9 @@ const GuessDistanceModal = ({
           <p className="mb-4">
             You guessed{" "}
             <span className="text-primary font-semibold">
-              {distanceToPinRef.current > 1000
-                ? (distanceToPinRef.current / 1000).toFixed(2) + "km"
-                : distanceToPinRef.current.toFixed(2) + "m"}{" "}
+              {distanceToGuessedPin > 1000
+                ? (distanceToGuessedPin / 1000).toFixed(2) + "km"
+                : distanceToGuessedPin.toFixed(2) + "m"}{" "}
             </span>
             away from the picture and your score is{" "}
             <span className="text-primary font-semibold">{score}</span>! Good
@@ -107,7 +101,7 @@ const GuessDistanceModal = ({
           </DrawerTrigger>
         </div>
         <DrawerContent>
-          {distanceToPinRef.current < thresholdDistance ? (
+          {distanceToGuessedPin < thresholdDistance ? (
             <div className="p-4">
               <h2>
                 {" "}

--- a/app/_components/GuessDistanceModal.tsx
+++ b/app/_components/GuessDistanceModal.tsx
@@ -12,30 +12,29 @@ import { Label } from "@radix-ui/react-label";
 const GuessDistanceModal = ({
   guessedPin,
   setGuessedPin,
-  // guessPoiPosition,
   userCoordinates,
   score,
 }: {
   guessedPin: Pin;
-  // guessPoiPosition: Coordinates;
   setGuessedPin: (arg0: Pin | null) => void;
   userCoordinates: Coordinates;
   score: number | null;
 }) => {
-  const [distanceToPin, setDistancePin] = useState<number>(0);
   const [hint, setHint] = useState<string>("");
   const drawerRef = useRef<HTMLButtonElement>(null); // Ref for the Done button
   const thresholdDistance = 20;
+  const distanceToPinRef = useRef<number>(handleDistanceToPin(guessedPin, userCoordinates));
 
   useEffect(() => {
-    if (!guessedPin) return;
-    handleDistanceToPin(guessedPin, userCoordinates);
-  }, [guessedPin]);
+    console.log("Guess Modal Mounted");
 
-  const handleDistanceToPin = (
+    return () => console.log("Unmounting");
+  },[]);
+
+  function handleDistanceToPin(
     guessedPin: Pin,
     userCoordinates: Coordinates
-  ) => {
+  ) {
     const pinCoordinates: Coordinates = {
       longitude: guessedPin.exact_longitude,
       latitude: guessedPin.exact_latitude,
@@ -45,8 +44,8 @@ const GuessDistanceModal = ({
       userCoordinates,
       pinCoordinates
     );
-    setDistancePin(distance);
-  };
+    return distance;
+  }
 
   const handleSubmitHint = async () => {
     const hintData = {
@@ -95,9 +94,9 @@ const GuessDistanceModal = ({
           <p className="mb-4">
             You guessed{" "}
             <span className="text-primary font-semibold">
-              {distanceToPin > 1000
-                ? (distanceToPin / 1000).toFixed(2) + "km"
-                : distanceToPin.toFixed(2) + "m"}{" "}
+              {distanceToPinRef.current > 1000
+                ? (distanceToPinRef.current / 1000).toFixed(2) + "km"
+                : distanceToPinRef.current.toFixed(2) + "m"}{" "}
             </span>
             away from the picture and your score is{" "}
             <span className="text-primary font-semibold">{score}</span>! Good
@@ -108,7 +107,7 @@ const GuessDistanceModal = ({
           </DrawerTrigger>
         </div>
         <DrawerContent>
-          {distanceToPin < thresholdDistance ? (
+          {distanceToPinRef.current < thresholdDistance ? (
             <div className="p-4">
               <h2>
                 {" "}
@@ -132,7 +131,6 @@ const GuessDistanceModal = ({
                   ref={drawerRef}
                   onClick={() => {
                     handleSubmitClick();
-                    // setGuessPoiPosition(null);
                     setGuessedPin(null);
                   }}
                   className="w-full"
@@ -144,7 +142,6 @@ const GuessDistanceModal = ({
                   ref={drawerRef}
                   onClick={() => {
                     handleSubmitClick;
-                    // setGuessPoiPosition(null);
                     setGuessedPin(null);
                   }}
                   className="w-full"
@@ -161,7 +158,6 @@ const GuessDistanceModal = ({
                 variant={"link"}
                 ref={drawerRef}
                 onClick={() => {
-                  // setGuessPoiPosition(null);
                   setGuessedPin(null);
                 }}
                 className="w-full"


### PR DESCRIPTION
# Description

The guess distance displayed on the modal should not longer be out of sync and display the guess distance properly. 

## Card Link
https://3.basecamp.com/5802516/buckets/37608217/card_tables/cards/7508335162

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This can be tested by constanly moving large distances before submitting a guess. Best on browser to move between longer distances.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
