### PR TITLE
chore: add comment to handleSetClosestNotCompletedPin to indicate tha…

### DIFF
--- a/app/_components/MapContainer.tsx
+++ b/app/_components/MapContainer.tsx
@@ -176,7 +176,7 @@ function MapInner() {
 
   /**
    * Sets closestNotCompletedPin to the closes pin BY POSITION
-   * Currently does not account for filters
+   * Accounts for the toggled filters
    * @param position
    */
   const handleSetClosestNotCompletedPin = (position: GeolocationPosition) => {
@@ -188,9 +188,13 @@ function MapInner() {
     let shortestDistance: number = Number.MAX_SAFE_INTEGER;
     let closestPin: Pin | null = null;
 
-    for (const pin of poiData) {
-      if (pin.is_completed) continue;
+    const pinsAfterFiltering = poiData.filter((pin) => {
+      return (pin.is_completed) ? false :
+      (selectedFilters.length === 0) ? true 
+      : selectedFilters.every((tag) => pin.tags.includes(tag))
+    })
 
+    for (const pin of pinsAfterFiltering) {
       const pinCoordinates: Coordinates = {
         longitude: pin.search_longitude,
         latitude: pin.search_latitude,


### PR DESCRIPTION
# Description

Closest non completed pin now sets itself based on the current filter settings. 
Based on how the algorithm works, it doesn't calculate the closest pin until the geolocation detects a change in coordinates. **This is intentional**.

## Card Link
https://3.basecamp.com/5802516/buckets/37608217/card_tables/cards/7508331681

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This can be tested by setting a filter and moving locations. The closest poi at the top will indicate the closest non completed pin with filters in consideration.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
