### PR TITLE
PR | Fix level display

### DIFF
--- a/app/_components/LevelContainer.tsx
+++ b/app/_components/LevelContainer.tsx
@@ -61,9 +61,7 @@ const LevelContainer = ({ levelAndXp }: { levelAndXp: levelAndXp }) => {
 
   return (
     <div className="fixed bottom-40 left-4 w-40" key={levelKey}>
-      {currentLevel === 0 ? (
-        <div></div>
-      ) : (
+      {currentLevel === 0 ? null : (
         <>
           <p>level{currentLevel}</p>
           <Progress value={progress} />

--- a/app/_components/LevelContainer.tsx
+++ b/app/_components/LevelContainer.tsx
@@ -31,13 +31,11 @@ const LevelContainer = ({ levelAndXp }: { levelAndXp: levelAndXp }) => {
 
     //written in use effect to trigger dependency
     const handleLevelUp = async () => {
-      //handle /refresh to not animate progressbar
       if (currentLevel === 0) {
-        setCurrentLevel(level);
         setProgress(progressPercentage);
+        setCurrentLevel(level);
         return;
       }
-
       // Player leveled up
       if (level > currentLevel) {
         //frame 1
@@ -63,8 +61,14 @@ const LevelContainer = ({ levelAndXp }: { levelAndXp: levelAndXp }) => {
 
   return (
     <div className="fixed bottom-40 left-4 w-40" key={levelKey}>
-      <p>level{currentLevel}</p>
-      <Progress value={progress} />
+      {currentLevel === 0 ? (
+        <div></div>
+      ) : (
+        <>
+          <p>level{currentLevel}</p>
+          <Progress value={progress} />
+        </>
+      )}
     </div>
   );
 };

--- a/app/_components/MapContainer.tsx
+++ b/app/_components/MapContainer.tsx
@@ -69,7 +69,7 @@ function MapInner() {
   const [levelAndXp, setLevelAndXp] = useState<levelAndXp>({
     level: 0,
     totalXp: 0,
-    xpToNextLevel: 0,
+    xpToNextLevel: 10000000,
   });
 
   // Default camera map when user opens the app
@@ -212,10 +212,12 @@ function MapInner() {
     let closestPin: Pin | null = null;
 
     const pinsAfterFiltering = poiData.filter((pin) => {
-      return (pin.is_completed) ? false :
-      (selectedFilters.length === 0) ? true 
-      : selectedFilters.every((tag) => pin.tags.includes(tag))
-    })
+      return pin.is_completed
+        ? false
+        : selectedFilters.length === 0
+        ? true
+        : selectedFilters.every((tag) => pin.tags.includes(tag));
+    });
 
     for (const pin of pinsAfterFiltering) {
       const pinCoordinates: Coordinates = {

--- a/app/_components/MapContainer.tsx
+++ b/app/_components/MapContainer.tsx
@@ -69,7 +69,7 @@ function MapInner() {
   const [levelAndXp, setLevelAndXp] = useState<levelAndXp>({
     level: 0,
     totalXp: 0,
-    xpToNextLevel: 10000000,
+    xpToNextLevel: 0,
   });
 
   // Default camera map when user opens the app


### PR DESCRIPTION
# Description

When going from the leaderbaord or refreshing the map, level0(inital state) was displayed for a second.
I added an invisable div that hides the initial state until the current level of the player is ready to go.

## Card Link
https://3.basecamp.com/5802516/buckets/37608217/card_tables/cards/7511179969

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Manually, attached Video of proof

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

