### PR TITLE
fix: error message display when email or password invalid and insufficient password length

### DIFF
--- a/app/_actions/authenticationActions.ts
+++ b/app/_actions/authenticationActions.ts
@@ -68,11 +68,10 @@ export async function createUser(
 export async function loginUser(email: string, password: string) {
   localStorage.removeItem("levelAndXp"); //if other user creates second account.
   try {
-    const uuid = await loginEmailPassword(email, password);
-    if (!uuid) throw "Could not find user";
+    await loginEmailPassword(email, password);
     alert("Login successful!");
   } catch (error) {
-    alert("Login failed!");
+    alert((error as Error).message);
     console.error(error);
   }
 }

--- a/app/_utils/authentication.ts
+++ b/app/_utils/authentication.ts
@@ -12,6 +12,17 @@ import {
  * Attempts to login the user based on the credentials in Google Firebase Authentication.
  * @returns uuid string
  */
+
+// Define a type for Firebase error
+interface FirebaseAuthError extends Error {
+  code: string;
+}
+
+// Type guard for Firebase error
+const isFirebaseAuthError = (error: unknown): error is FirebaseAuthError => {
+  return (error as FirebaseAuthError).code !== undefined;
+};
+
 const loginEmailPassword = async (
   email: string,
   password: string
@@ -27,6 +38,17 @@ const loginEmailPassword = async (
     );
     return userCredential.user.uid;
   } catch (e: unknown) {
+    if (isFirebaseAuthError(e)) {
+      const errorCode = e.code;
+      console.log("errorCode: ", errorCode);
+      if (errorCode === 'auth/invalid-credential') {
+        throw new Error('Email or password incorrect! Please try again.');
+      } else {
+        throw new Error('Login unsuccessful due to internal error. Please try again later.');
+      }
+    } else if (e instanceof Error) {
+      throw new Error(e.message);
+    }
     console.error(e);
   }
 };

--- a/app/login/LoginPage.tsx
+++ b/app/login/LoginPage.tsx
@@ -51,6 +51,10 @@ const LoginPage: React.FC = () => {
     try {
       if (!user.creatingEmail || !user.creatingPassword || !user.displayName)
         throw "Invalid User/Password/Display Name";
+      if (user.creatingPassword.length < 6) {
+        alert("Password must have at least 6 characters, please try again.");
+        throw "Insufficient password length";
+      }
       await createUser(
         user.creatingEmail,
         user.creatingPassword,


### PR DESCRIPTION
# Description

Browser alerts with error messages to inform players when invalid email or password were entered upon login, also when new player tries to create new account with password fewer than 6 characters.

## Card Link
https://3.basecamp.com/5802516/buckets/37608217/card_tables/cards/7512294908
https://3.basecamp.com/5802516/buckets/37608217/card_tables/cards/7511686873

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested in browser localhost with both local servers running.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
