### PR TITLE
feat: use Params to trigger the open state of collection

### DIFF
--- a/app/_components/FooterMenu.tsx
+++ b/app/_components/FooterMenu.tsx
@@ -21,7 +21,7 @@ export default function FooterMenu({
           </ButtonIconCircle>
         </Link>
 
-        <Link href={"/map"}>
+        <Link href={"/map?tab=collection"}>
           <ButtonIconCircle
             variant={variant === "collection" ? "active" : "default"}
             text="collection"

--- a/app/_components/Poidex.tsx
+++ b/app/_components/Poidex.tsx
@@ -2,6 +2,8 @@ import PoidexModal from "./PoidexModal";
 import { Pin } from "../_utils/global";
 import { BsCollectionFill } from "react-icons/bs";
 import { ButtonIconCircle } from "./ui/MenuIconCircle";
+import { useSearchParams } from "next/navigation";
+import { useEffect } from "react";
 
 interface PoidexProps {
   pins: Pin[];
@@ -14,6 +16,15 @@ const Poidex = ({
   setShowPoidex,
   showPoidex,
 }: PoidexProps): React.JSX.Element => {
+  const searchParams = useSearchParams();
+  const tab = searchParams.get("tab");
+
+  useEffect(() => {
+    if (tab === "collection") {
+      setShowPoidex(true);
+    }
+  }, [tab]);
+
   return (
     <>
       <ButtonIconCircle


### PR DESCRIPTION
# Description

Users can now click the collection menu in the footer menu bar to navigate to the /map and automatically open the collection right away.

## Card Link
https://3.basecamp.com/5802516/buckets/37608217/card_tables/cards/7512333255

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual test

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
