### PR TITLE
chore: change h-screen to h-[100svh], disable input zoom on iOS

### DIFF
--- a/app/_components/PoiPopup.tsx
+++ b/app/_components/PoiPopup.tsx
@@ -24,7 +24,7 @@ export default function PoiPopup({
 }): JSX.Element {
   // RETURN
   return (
-    <main className="flex h-screen flex-col items-center justify-between">
+    <main className="flex h-[100svh] flex-col items-center justify-between">
       <Dialog defaultOpen>
         <DialogTrigger />
         <DialogContent onClick={() => setShowPopup(false)}>

--- a/app/_components/PoiPopup.tsx
+++ b/app/_components/PoiPopup.tsx
@@ -24,7 +24,7 @@ export default function PoiPopup({
 }): JSX.Element {
   // RETURN
   return (
-    <main className="flex h-[100svh] flex-col items-center justify-between">
+    <main className="flex h-svh flex-col items-center justify-between">
       <Dialog defaultOpen>
         <DialogTrigger />
         <DialogContent onClick={() => setShowPopup(false)}>

--- a/app/_components/PoidexModal.tsx
+++ b/app/_components/PoidexModal.tsx
@@ -35,7 +35,7 @@ const PoidexModal: React.FC<PoidexModalProps> = ({ pins, setShowPoidex }) => {
   };
 
   return (
-    <main className="fixed flex h-[100svh] flex-col items-center justify-between">
+    <main className="fixed flex h-svh flex-col items-center justify-between">
       <Popover defaultOpen>
         <PopoverContent>
           <Dialog defaultOpen>

--- a/app/_components/PoidexModal.tsx
+++ b/app/_components/PoidexModal.tsx
@@ -35,7 +35,7 @@ const PoidexModal: React.FC<PoidexModalProps> = ({ pins, setShowPoidex }) => {
   };
 
   return (
-    <main className="fixed flex h-screen flex-col items-center justify-between">
+    <main className="fixed flex h-[100svh] flex-col items-center justify-between">
       <Popover defaultOpen>
         <PopoverContent>
           <Dialog defaultOpen>

--- a/app/_components/PopoverCard.tsx
+++ b/app/_components/PopoverCard.tsx
@@ -19,7 +19,7 @@ const PopoverCard = ({
   setCheckLevel: (arg: boolean) => void;
 }) => {
   return (
-    <div className="fixed top-0 left-0 w-screen h-screen">
+    <div className="fixed top-0 left-0 w-screen h-[100svh]">
       <Popover defaultOpen>
         <PopoverContent>
           {setShowPopup && userCoordinates && (

--- a/app/_components/PopoverCard.tsx
+++ b/app/_components/PopoverCard.tsx
@@ -19,7 +19,7 @@ const PopoverCard = ({
   setCheckLevel: (arg: boolean) => void;
 }) => {
   return (
-    <div className="fixed top-0 left-0 w-screen h-[100svh]">
+    <div className="fixed top-0 left-0 w-screen h-svh">
       <Popover defaultOpen>
         <PopoverContent>
           {setShowPopup && userCoordinates && (

--- a/app/_components/ui/dialog.tsx
+++ b/app/_components/ui/dialog.tsx
@@ -20,7 +20,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-[999] w-screen h-[100svh] bg-black/40 isolate data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[999] w-screen h-svh bg-black/40 isolate data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "h-[100svh] w-screen flex justify-center items-center shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+        "h-svh w-screen flex justify-center items-center shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
         className
       )}
     >

--- a/app/_components/ui/dialog.tsx
+++ b/app/_components/ui/dialog.tsx
@@ -20,7 +20,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-[999] w-screen h-screen bg-black/40 isolate data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[999] w-screen h-[100svh] bg-black/40 isolate data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "h-screen w-screen flex justify-center items-center shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+        "h-[100svh] w-screen flex justify-center items-center shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
         className
       )}
     >

--- a/app/_components/ui/loading.tsx
+++ b/app/_components/ui/loading.tsx
@@ -3,7 +3,7 @@ import { FaLocationDot } from "react-icons/fa6";
 const LoadingSkeleton = () => {
   return (
     <>
-      <div className="flex flex-col items-center justify-center gap-4 w-screen h-screen px-4">
+      <div className="flex flex-col items-center justify-center gap-4 w-screen h-[100svh] px-4">
         <FaLocationDot size={80} className="text-primary animate-bounce z-20" />
         <div className="bg-secondary-300 text-white h-10 w-24 rounded-[100%] -translate-y-10 shadow-lg flex justify-center items-center"></div>
       </div>

--- a/app/_components/ui/loading.tsx
+++ b/app/_components/ui/loading.tsx
@@ -3,7 +3,7 @@ import { FaLocationDot } from "react-icons/fa6";
 const LoadingSkeleton = () => {
   return (
     <>
-      <div className="flex flex-col items-center justify-center gap-4 w-screen h-[100svh] px-4">
+      <div className="flex flex-col items-center justify-center gap-4 w-screen h-svh px-4">
         <FaLocationDot size={80} className="text-primary animate-bounce z-20" />
         <div className="bg-secondary-300 text-white h-10 w-24 rounded-[100%] -translate-y-10 shadow-lg flex justify-center items-center"></div>
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,11 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-html,
-body {
-  touch-action: none;
-}
-
 body {
   overflow: hidden;
   overscroll-behavior-y: none;

--- a/app/login/LoginPage.tsx
+++ b/app/login/LoginPage.tsx
@@ -321,7 +321,7 @@ const LoginPage: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center gap-4 w-screen h-screen px-4">
+    <div className="flex flex-col items-center justify-center gap-4 w-screen h-[100svh] px-4 bg-gray-200">
       {!isLoading ? (
         <>
           {renderLoginWindow(loginWindowStatus)}

--- a/app/login/LoginPage.tsx
+++ b/app/login/LoginPage.tsx
@@ -321,7 +321,7 @@ const LoginPage: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center gap-4 w-screen h-[100svh] px-4 bg-gray-200">
+    <div className="flex flex-col items-center justify-center gap-4 w-screen h-svh px-4 bg-gray-200">
       {!isLoading ? (
         <>
           {renderLoginWindow(loginWindowStatus)}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,8 +3,14 @@ import { AuthProvider } from "../_components/useContext/AuthContext";
 
 export default function Home(): JSX.Element {
   return (
-    <AuthProvider>
-      <LoginPage />
-    </AuthProvider>
+    <html lang="en">
+      <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1, maximum-scale=1"
+      ></meta>
+      <AuthProvider>
+        <LoginPage />
+      </AuthProvider>
+    </html>
   );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,10 +3,8 @@ import { AuthProvider } from "../_components/useContext/AuthContext";
 
 export default function Home(): JSX.Element {
   return (
-    <div className="absolute overflow-hidden inset-0 bg-gray-200">
-      <AuthProvider>
-        <LoginPage />
-      </AuthProvider>
-    </div>
+    <AuthProvider>
+      <LoginPage />
+    </AuthProvider>
   );
 }

--- a/app/map/layout.tsx
+++ b/app/map/layout.tsx
@@ -7,8 +7,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body>
+    <html lang="en" className="touch-none">
+      <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1, maximum-scale=1"
+      ></meta>
+      <body className="touch-none">
         <Suspense fallback={<Loading />}>{children}</Suspense>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import FooterMenu from "./_components/FooterMenu";
 export default function Home(): JSX.Element {
   // RETURN
   return (
-    <main className="text-primary bg-gray-200 flex min-h-screen flex-col items-center justify-start p-24">
+    <main className="text-primary bg-gray-200 flex min-h-[100svh] flex-col items-center justify-start p-24">
       <h1>Got lost?</h1>
       <Link
         href="/map"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import FooterMenu from "./_components/FooterMenu";
 export default function Home(): JSX.Element {
   // RETURN
   return (
-    <main className="text-primary bg-gray-200 flex min-h-[100svh] flex-col items-center justify-start p-24">
+    <main className="text-primary bg-gray-200 flex min-h-svh flex-col items-center justify-start p-24">
       <h1>Got lost?</h1>
       <Link
         href="/map"


### PR DESCRIPTION
# Description

Due to iOS move the search bar to the bottom of the screen which cause some unexpected bug, change all Tailwind h-screen to h-[100svh] to prevent that to happen again.

- run `npm run build`
- run command `ifconfig | grep "inet " | grep -v 127.0.0.1` in the terminal
- go to the `[IP address]:[PORT]` on your mobile.
- enjoy!
(you cannot connect to the Backend server for this.)

## Card Link
https://3.basecamp.com/5802516/buckets/37608217/card_tables/cards/7512399178/edit

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual test on iOS device in Internal network.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
