### PR TITLE
fix: remove tab dependency from search params

### DIFF
--- a/app/_components/Poidex.tsx
+++ b/app/_components/Poidex.tsx
@@ -23,7 +23,7 @@ const Poidex = ({
     if (tab === "collection") {
       setShowPoidex(true);
     }
-  }, [tab]);
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
# Description

To fix an bug about the location icon flickering on android devices and prevent framrate drops
